### PR TITLE
get origin from header

### DIFF
--- a/mevshare/api.go
+++ b/mevshare/api.go
@@ -95,8 +95,10 @@ func (m *API) SendBundle(ctx context.Context, bundle SendMevBundleArgs) (SendMev
 	m.knownBundleCache.Add(hash, struct{}{})
 
 	signerAddress := jsonrpcserver.GetSigner(ctx)
+	origin := jsonrpcserver.GetOrigin(ctx)
 	bundle.Metadata.Signer = signerAddress
 	bundle.Metadata.ReceivedAt = hexutil.Uint64(uint64(time.Now().UnixMicro()))
+	bundle.Metadata.OriginID = origin
 
 	if hasUnmatchedHash {
 		var unmatchedHash common.Hash

--- a/mevshare/bundle_validation.go
+++ b/mevshare/bundle_validation.go
@@ -13,9 +13,6 @@ var (
 	ErrBundleTooDeep            = errors.New("bundle too deep")
 	ErrInvalidBundleConstraints = errors.New("invalid bundle constraints")
 	ErrInvalidBundlePrivacy     = errors.New("invalid bundle privacy")
-	ErrInvalidBundleMetadata    = errors.New("invalid bundle metadata")
-
-	maxOriginIDLength = 255
 )
 
 func cleanBody(bundle *SendMevBundleArgs) {
@@ -208,9 +205,7 @@ func validateBundleInner(level int, bundle *SendMevBundleArgs, currentBlock uint
 	bundle.Metadata.BundleHash = hash
 	bundle.Metadata.BodyHashes = bodyHashes
 	bundle.Metadata.Signer = common.Address{}
-	if len(bundle.Metadata.OriginID) > maxOriginIDLength {
-		return hash, txs, unmatched, ErrInvalidBundleMetadata
-	}
+	bundle.Metadata.OriginID = ""
 	bundle.Metadata.ReceivedAt = 0
 
 	return hash, txs, unmatched, nil


### PR DESCRIPTION
## 📝 Summary

Adds support for "x-flashbots-origin" header on the relay.

## ⛱ Motivation and Context

x-flashbots-origin is a new header on the relay that lets user to specify order flow origin


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
