### PR TITLE
recheduled failed bundles if they are not expired yet

### DIFF
--- a/mevshare/sim_queue.go
+++ b/mevshare/sim_queue.go
@@ -109,7 +109,7 @@ type SimulationWorker struct {
 	backgroundWg      *sync.WaitGroup
 }
 
-func (w *SimulationWorker) Process(ctx context.Context, data []byte) error {
+func (w *SimulationWorker) Process(ctx context.Context, data []byte, info simqueue.QueueItemInfo) error {
 	var bundle SendMevBundleArgs
 	err := json.Unmarshal(data, &bundle)
 	if err != nil {
@@ -139,7 +139,7 @@ func (w *SimulationWorker) Process(ctx context.Context, data []byte) error {
 		defer w.backgroundWg.Done()
 		resCtx, cancel := context.WithTimeout(context.Background(), consumeSimulationTimeout)
 		defer cancel()
-		err = w.simRes.SimulatedBundle(resCtx, &bundle, result)
+		err = w.simRes.SimulatedBundle(resCtx, &bundle, result, info)
 		if err != nil {
 			w.log.Error("Failed to consume matched share bundle", zap.Error(err))
 		}

--- a/mevshare/sim_queue.go
+++ b/mevshare/sim_queue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"sync"
 	"time"
 
@@ -125,7 +126,7 @@ func (w *SimulationWorker) Process(ctx context.Context, data []byte, info simque
 	}
 
 	// Try to re-simulate bundle if it failed
-	if !result.Success {
+	if !result.Success && isErrorRecoverable(result.Error) {
 		max := bundle.Inclusion.MaxBlock
 		state := result.StateBlock
 		// If state block is N, that means simulation for target block N+1 was tried
@@ -145,4 +146,8 @@ func (w *SimulationWorker) Process(ctx context.Context, data []byte, info simque
 		}
 	}()
 	return nil
+}
+
+func isErrorRecoverable(message string) bool {
+	return !strings.Contains(message, "nonce too low")
 }

--- a/mevshare/sim_result_backend.go
+++ b/mevshare/sim_result_backend.go
@@ -3,6 +3,7 @@ package mevshare
 import (
 	"context"
 	"errors"
+	"github.com/flashbots/mev-share-node/simqueue"
 
 	"go.uber.org/zap"
 )
@@ -10,7 +11,7 @@ import (
 // SimulationResult is responsible for processing simulation results
 // NOTE: That error should be returned only if simulation should be retried, for example if redis is down or none of the builders responded
 type SimulationResult interface {
-	SimulatedBundle(ctx context.Context, args *SendMevBundleArgs, result *SimMevBundleResponse) error
+	SimulatedBundle(ctx context.Context, args *SendMevBundleArgs, result *SimMevBundleResponse, info simqueue.QueueItemInfo) error
 }
 
 type Storage interface {
@@ -45,7 +46,8 @@ func NewSimulationResultBackend(log *zap.Logger, hint HintBackend, builders []Bu
 
 // SimulatedBundle is called when simulation is done
 // NOTE: we return error only if we want to retry the simulation
-func (s *SimulationResultBackend) SimulatedBundle(ctx context.Context, bundle *SendMevBundleArgs, sim *SimMevBundleResponse) error {
+func (s *SimulationResultBackend) SimulatedBundle(ctx context.Context,
+	bundle *SendMevBundleArgs, sim *SimMevBundleResponse, queueInfo simqueue.QueueItemInfo) error {
 	logger := s.log.With(zap.String("bundle", bundle.Metadata.BundleHash.Hex()))
 
 	logger.Info("Simulated bundle",
@@ -53,7 +55,9 @@ func (s *SimulationResultBackend) SimulatedBundle(ctx context.Context, bundle *S
 		zap.String("gwei_eff_gas_price", formatUnits(sim.MevGasPrice.ToInt(), "gwei")),
 		zap.String("eth_profit", formatUnits(sim.Profit.ToInt(), "eth")),
 		zap.String("eth_refundable_value", formatUnits(sim.RefundableValue.ToInt(), "eth")),
-		zap.Uint64("gas_used", uint64(sim.GasUsed)))
+		zap.Uint64("gas_used", uint64(sim.GasUsed)),
+		zap.Int("retries", queueInfo.Retries),
+	)
 
 	// failed bundle does not go to the builder
 	err := s.store.InsertBundleForStats(ctx, bundle, sim)

--- a/mevshare/sim_result_backend.go
+++ b/mevshare/sim_result_backend.go
@@ -3,8 +3,8 @@ package mevshare
 import (
 	"context"
 	"errors"
-	"github.com/flashbots/mev-share-node/simqueue"
 
+	"github.com/flashbots/mev-share-node/simqueue"
 	"go.uber.org/zap"
 )
 
@@ -47,7 +47,8 @@ func NewSimulationResultBackend(log *zap.Logger, hint HintBackend, builders []Bu
 // SimulatedBundle is called when simulation is done
 // NOTE: we return error only if we want to retry the simulation
 func (s *SimulationResultBackend) SimulatedBundle(ctx context.Context,
-	bundle *SendMevBundleArgs, sim *SimMevBundleResponse, queueInfo simqueue.QueueItemInfo) error {
+	bundle *SendMevBundleArgs, sim *SimMevBundleResponse, queueInfo simqueue.QueueItemInfo,
+) error {
 	logger := s.log.With(zap.String("bundle", bundle.Metadata.BundleHash.Hex()))
 
 	logger.Info("Simulated bundle",

--- a/simqueue/multiworker.go
+++ b/simqueue/multiworker.go
@@ -14,12 +14,12 @@ func MultipleWorkers(processFunc ProcessFunc, n int, limit rate.Limit, burst int
 
 	process := make([]ProcessFunc, n)
 	for i := 0; i < n; i++ {
-		process[i] = func(ctx context.Context, data []byte) error {
+		process[i] = func(ctx context.Context, data []byte, info QueueItemInfo) error {
 			err := rateLimiter.Wait(ctx)
 			if err != nil {
 				return err
 			}
-			return processFunc(ctx, data)
+			return processFunc(ctx, data, info)
 		}
 	}
 	return process


### PR DESCRIPTION
## 📝 Summary

Before, bundle valid in some block range that fails first simulation somewhere in that range was discarded. 

Now, we retry simulation of that bundle for multiple blocks in that range until it succeeds or expires.

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
