### PR TITLE
Add x-orderflow-origin header when sbundles are sent to builders

### DIFF
--- a/mevshare/builders.go
+++ b/mevshare/builders.go
@@ -73,7 +73,12 @@ func LoadBuilderConfig(file string) (BuildersBackend, error) {
 			return BuildersBackend{}, err
 		}
 
-		cl := jsonrpc.NewClientWithOpts(builder.URL, &jsonrpc.RPCClientOpts{CustomHeaders: map[string]string{orderflowHeader: flashbotsSource}})
+		cl := jsonrpc.NewClientWithOpts(builder.URL, &jsonrpc.RPCClientOpts{
+			HTTPClient:         nil,
+			CustomHeaders:      map[string]string{orderflowHeader: flashbotsSource},
+			AllowUnknownFields: false,
+			DefaultRequestID:   0,
+		})
 		builderBackend := JSONRPCBuilderBackend{
 			Name:   strings.ToLower(builder.Name),
 			Client: cl,

--- a/mevshare/builders.go
+++ b/mevshare/builders.go
@@ -22,6 +22,9 @@ type BuilderAPI uint8
 const (
 	BuilderAPIRefundRecipient BuilderAPI = iota
 	BuilderAPIMevShareBeta1
+
+	orderflowHeader = "x-orderflow-origin"
+	flashbotsSource = "flashbots"
 )
 
 func parseBuilderAPI(api string) (BuilderAPI, error) {
@@ -70,9 +73,10 @@ func LoadBuilderConfig(file string) (BuildersBackend, error) {
 			return BuildersBackend{}, err
 		}
 
+		cl := jsonrpc.NewClientWithOpts(builder.URL, &jsonrpc.RPCClientOpts{CustomHeaders: map[string]string{orderflowHeader: flashbotsSource}})
 		builderBackend := JSONRPCBuilderBackend{
 			Name:   strings.ToLower(builder.Name),
-			Client: jsonrpc.NewClient(builder.URL),
+			Client: cl,
 			API:    api,
 		}
 

--- a/mevshare/builders.go
+++ b/mevshare/builders.go
@@ -23,8 +23,7 @@ const (
 	BuilderAPIRefundRecipient BuilderAPI = iota
 	BuilderAPIMevShareBeta1
 
-	orderflowHeader = "x-orderflow-origin"
-	flashbotsSource = "flashbots"
+	OrderflowHeaderName = "x-orderflow-origin"
 )
 
 func parseBuilderAPI(api string) (BuilderAPI, error) {
@@ -46,6 +45,8 @@ type BuildersConfig struct {
 		Internal bool   `yaml:"internal,omitempty"`
 		Disabled bool   `yaml:"disabled,omitempty"`
 	} `yaml:"builders"`
+	OrderflowHeader      bool   `yaml:"orderflowHeader,omitempty"`
+	OrderflowHeaderValue string `yaml:"orderflowHeaderValue,omitempty"`
 }
 
 // LoadBuilderConfig parses a builder config from a file
@@ -59,6 +60,11 @@ func LoadBuilderConfig(file string) (BuildersBackend, error) {
 	err = yaml.Unmarshal(data, &config)
 	if err != nil {
 		return BuildersBackend{}, err
+	}
+
+	customHeaders := make(map[string]string)
+	if config.OrderflowHeader {
+		customHeaders[OrderflowHeaderName] = config.OrderflowHeaderValue
 	}
 
 	externalBuilders := make([]JSONRPCBuilderBackend, 0)
@@ -75,7 +81,7 @@ func LoadBuilderConfig(file string) (BuildersBackend, error) {
 
 		cl := jsonrpc.NewClientWithOpts(builder.URL, &jsonrpc.RPCClientOpts{
 			HTTPClient:         nil,
-			CustomHeaders:      map[string]string{orderflowHeader: flashbotsSource},
+			CustomHeaders:      customHeaders,
 			AllowUnknownFields: false,
 			DefaultRequestID:   0,
 		})


### PR DESCRIPTION
## 📝 Summary

Add new header so that builders can distinguish our orderflow

## ⛱ Motivation and Context

Builders need to be able to exclude our private orderflow from some of their reporting

## 📚 References



---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
