### PR TITLE
Feature/ofa 212 allow reprocessing sbundles

### DIFF
--- a/mevshare/api.go
+++ b/mevshare/api.go
@@ -107,7 +107,7 @@ func (m *API) SendBundle(ctx context.Context, bundle SendMevBundleArgs) (SendMev
 		return SendMevBundleResponse{}, err
 	}
 	if oldBundle, ok := m.knownBundleCache.Get(hash); ok {
-		if newerInclusion(&oldBundle, &bundle) {
+		if !newerInclusion(&oldBundle, &bundle) {
 			logger.Debug("bundle already known, ignoring", zap.String("hash", hash.Hex()))
 			return SendMevBundleResponse{hash}, nil
 		}

--- a/mevshare/api.go
+++ b/mevshare/api.go
@@ -55,7 +55,7 @@ type API struct {
 	simRateLimiter *rate.Limiter
 	builders       BuildersBackend
 
-	knownBundleCache  *lru.Cache[common.Hash, struct{}]
+	knownBundleCache  *lru.Cache[common.Hash, SendMevBundleArgs]
 	cancellationCache *RedisCancellationCache
 }
 
@@ -75,7 +75,7 @@ func NewAPI(
 		simRateLimiter: rate.NewLimiter(simRateLimit, 1),
 		builders:       builders,
 
-		knownBundleCache:  lru.NewCache[common.Hash, struct{}](bundleCacheSize),
+		knownBundleCache:  lru.NewCache[common.Hash, SendMevBundleArgs](bundleCacheSize),
 		cancellationCache: cancellationCache,
 	}
 }
@@ -106,11 +106,13 @@ func (m *API) SendBundle(ctx context.Context, bundle SendMevBundleArgs) (SendMev
 		logger.Warn("failed to validate bundle", zap.Error(err))
 		return SendMevBundleResponse{}, err
 	}
-	if _, ok := m.knownBundleCache.Get(hash); ok {
-		logger.Debug("bundle already known, ignoring", zap.String("hash", hash.Hex()))
-		return SendMevBundleResponse{hash}, nil
+	if oldBundle, ok := m.knownBundleCache.Get(hash); ok {
+		if newerInclusion(&oldBundle, &bundle) {
+			logger.Debug("bundle already known, ignoring", zap.String("hash", hash.Hex()))
+			return SendMevBundleResponse{hash}, nil
+		}
 	}
-	m.knownBundleCache.Add(hash, struct{}{})
+	m.knownBundleCache.Add(hash, bundle)
 
 	signerAddress := jsonrpcserver.GetSigner(ctx)
 	origin := jsonrpcserver.GetOrigin(ctx)

--- a/mevshare/utils.go
+++ b/mevshare/utils.go
@@ -119,14 +119,14 @@ func RoundUpWithPrecision(number *big.Int, precisionDigits int) *big.Int {
 	return result
 }
 
-func newerInclusion(old *SendMevBundleArgs, new *SendMevBundleArgs) bool {
+func newerInclusion(old, newBundle *SendMevBundleArgs) bool {
 	if old == nil {
 		return true
 	}
-	if new == nil {
+	if newBundle == nil {
 		return false
 	}
-	if old.Inclusion.MaxBlock < new.Inclusion.MaxBlock {
+	if old.Inclusion.MaxBlock < newBundle.Inclusion.MaxBlock {
 		return true
 	}
 

--- a/mevshare/utils.go
+++ b/mevshare/utils.go
@@ -118,3 +118,17 @@ func RoundUpWithPrecision(number *big.Int, precisionDigits int) *big.Int {
 
 	return result
 }
+
+func newerInclusion(old *SendMevBundleArgs, new *SendMevBundleArgs) bool {
+	if old == nil {
+		return true
+	}
+	if new == nil {
+		return false
+	}
+	if old.Inclusion.MaxBlock < new.Inclusion.MaxBlock {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
## 📝 Summary

Sbundles that are not included can be sent once again and processed by the system

## ⛱ Motivation and Context

User can get effectively `stuck` when sending the same private transaction with low gas settings, so that tx is not included within 25 block-range. We now allow to send same tx with new blockInclusion settings

## 📚 References


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
